### PR TITLE
fixes #1, fixes archives sidebar styling

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
fixes issue #1: fixes a typo when defining the class of the h3 tag and the div in the archive_sidebar partial, changes _ to -

Changes to:

```
  <h3 class="sidebar-title"><%= sidebar.title %></h3>
  <div class="sidebar-body">
```

From:

```
  <h3 class="sidebar_title"><%= sidebar.title %></h3>
  <div class="sidebar_body">
```
