### PR TITLE
Resolved Issue: Inconsistent Sidebar Styles #1

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue #1  Changed code in the archives_sidebar view so that its html tags (div and h3) have the appropriate class names to affect the CSS styles required for sidebar titles and <li> elements. Previously, the attached class names for the divs and h3 were misspelled so the appropriate class-specific style  configurations in the stylesheets were not applied.
