### PR TITLE
FIXED Issue #1: Styling changes to sidebar 

### DIFF
--- a/app/assets/stylesheets/user-styles.css
+++ b/app/assets/stylesheets/user-styles.css
@@ -32,7 +32,6 @@ img.right {
   font-family: monospace;
 }
 
-
 #sidebar .sidebar-body li {
   list-style-type: circle;
 }

--- a/app/assets/stylesheets/user-styles.css
+++ b/app/assets/stylesheets/user-styles.css
@@ -32,14 +32,7 @@ img.right {
   font-family: monospace;
 }
 
-.sidebar_title {
-  font-family: monospace;
-}
 
 #sidebar .sidebar-body li {
-  list-style-type: circle;
-}
-
-#archives li {
   list-style-type: circle;
 }

--- a/app/assets/stylesheets/user-styles.css
+++ b/app/assets/stylesheets/user-styles.css
@@ -32,6 +32,14 @@ img.right {
   font-family: monospace;
 }
 
+.sidebar_title {
+  font-family: monospace;
+}
+
 #sidebar .sidebar-body li {
+  list-style-type: circle;
+}
+
+#archives li {
   list-style-type: circle;
 }

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
FIXED Issue #1: Inconsistent Sidebar Styles
All titles in the sidebar are consistent to Monospace.
All li bullets have been changed to circles within the sidebar.

class sidebar_title and class sidebar_body was shown in lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb

whereas 
class sidebar-title and class sidebar-body was shown in user-styles.css

Replaced the _ to - within lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb to fix the sidebar issues

Original

```
  <h3 class="sidebar_title"><%= sidebar.title %></h3>
  <div class="sidebar_body">

```

FIxed

```
  <h3 class="sidebar-title"><%= sidebar.title %></h3>
  <div class="sidebar-body">

```
