### PR TITLE
Sign-in form displays raw span html in input fields

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,11 +5,11 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <fieldset>
     <div class="form-group">
-      <%= f.text_field :login, class: 'form-control', placeholder: t('.login'), autofocus: true %>
+      <%= f.text_field :login, class: 'form-control', placeholder: "Login", autofocus: true %>
     </div>
 
     <div class="form-group">
-      <%= f.password_field :password, class: 'form-control', placeholder: t('.password'), autocomplete: 'off' %>
+      <%= f.password_field :password, class: 'form-control', placeholder: "Password", autocomplete: 'off' %>
     </div>
 
     <div class="checkbox">


### PR DESCRIPTION
Issue #7 

changed placeholders to  "Login"and "Password"
