### PR TITLE
fixes #2, Top Month Always Empty (Archive Sidebar)

### DIFF
--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -34,7 +34,7 @@ class ArchivesSidebar < Sidebar
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),
-        month: month - 1,
+        month: month - 2,
         year: year,
         article_count: entry.count
       }


### PR DESCRIPTION
**fixes** issue #2 : fixes an off by one error in the archives_sidebar model, changes month-1 to month-2.

Changes in lib/archives_sidebar/lib/archives_sidebar.rb:

```
month: month - 2,
```

From:

```
month: month - 1,
```
