### PR TITLE
fixes #1 - change to monospace and remove filled bulletpoints

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
I have corrected <a href="https://github.com/sf-wdi-30/publify_debugging_lab/issues/1">Issue #1</a>. There was a minor typo in the partial _content.html.erb for the archives sidebar view. The new fix will make the font monospace and the bullet point unfilled. This fix is successful because there doesn't exist a css class for sidebar_title. There does exist however, a sidebar-title class. 
