### PR TITLE
Top month fix #2

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe, articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Fix issue #2 

Removed  "+1" from: lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb line 8.

It seems like the whoever wrote the code made an error in syntax. Adding +1 here created an off-by-1 error. Removing this +1 fixed the issue and now the top month is populated with a post. 
