### PR TITLE
Fix to Issue #2 Top Month Always Empty

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar-body">
+  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)+1
+      month = (entry.month.to_i-1%12)+1
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
This change to /lib/archives_sidebar/lib/archives_sidebar.rb fixes issue #2. By adding -1 here:
month = (entry.month.to_i**-1**%12)+1  
this sets the correct month from an array as January would be at index zero and previously it was selecting from index 1 as 0%12= 0(january) but 1%12=1(february). In this particular case the most recent month should be September[index 8] but the logic made it select October[index 9]
