### PR TITLE
Fix #2 empty top month

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -17,7 +17,7 @@ class Admin::DashboardController < Admin::BaseController
     @statsdrafts = Article.drafts.where('created_at > ?', today).count
     @statspages = Page.where('published_at > ?', today).count
     @statuses = Note.where('published_at > ?', today).count
-    @statuserposts = Article.published.where('published_at > ?', today).count(conditions: { user_id: current_user.id })
+    @statuserposts = current_user.articles.published.where('published_at > ?', today).count
     @statcomments = Comment.where('created_at > ?', today).count
     @presumedspam = Comment.presumed_spam.where('created_at > ?', today).count
     @confirmed = Comment.ham.where('created_at > ?', today).count

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>

--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Fix for issue #2
In lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb --> removed +1 from articles_by_month_path to fix the off by one bug in the month links on the sidebar.
From: 
`<%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>`
To:
`<%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>`

However, the routes are now off by one so that when I click on September, the url says /2016/08...
