### PR TITLE
Fix #2 empty top month

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
In lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb --> removed +1 from articles_by_month_path to fix the off by one bug in the month links on the sidebar.
From: 
<%= link_to"#{month[:name]} #{counter}".html_safe, articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
To:
<%= link_to"#{month[:name]} #{counter}".html_safe, articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>

However, the routes are now off by one so that when I click on September, the url says /2016/08...
