### PR TITLE
BUG FIX: Months sorted incorrectly (Archive Sidebar)

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -2,7 +2,7 @@
   <h3 class="sidebar_title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
-      <% sidebar.archives.each do |month| %>
+      <% sidebar.archives.sort_by { |m| [m[:year], m[:month]] }.reverse.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
           <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>


### PR DESCRIPTION
Issue #3

the months in the archive sidebar are now displayed in reverse chronological order in view.

This was done by sorting the sidebar.archives array by year and month in reverse chronological order before sending it through iterator.
